### PR TITLE
Fix Supermicro redfish machine UUID not returned in proper format.

### DIFF
--- a/internal/uuid-endianness/uuid_test.go
+++ b/internal/uuid-endianness/uuid_test.go
@@ -3,7 +3,15 @@ package uuid
 import (
 	"bytes"
 	"testing"
+
+	"github.com/google/uuid"
 )
+
+func ConvertUUID(s string) []byte {
+	u := uuid.MustParse(s)
+	b, _ := u.MarshalBinary()
+	return b
+}
 
 func TestUuid(t *testing.T) {
 	var tests = []struct {
@@ -17,6 +25,10 @@ func TestUuid(t *testing.T) {
 		{
 			value:  []byte{0x99, 0x34, 0x5, 0x68, 0xf7, 0x75, 0x11, 0xe7, 0x8c, 0x3f, 0x9a, 0x21, 0x4c, 0xf0, 0x93, 0xae}, // 99340568-f775-11e7-8c3f-9a214cf093ae
 			expect: []byte{0x68, 0x5, 0x34, 0x99, 0x75, 0xf7, 0xe7, 0x11, 0x8c, 0x3f, 0x9a, 0x21, 0x4c, 0xf0, 0x93, 0xae}, // 68053499-75f7-e711-8c3f-9a214cf093ae
+		},
+		{
+			value:  ConvertUUID("00ecd471-0771-e911-8000-efbeaddeefbe"),
+			expect: ConvertUUID("71d4ec00-7107-11e9-8000-efbeaddeefbe"),
 		},
 	}
 


### PR DESCRIPTION
Needs to be converted to mixed endian.