### PR TITLE
fix vendor guessing bug

### DIFF
--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -2,8 +2,9 @@ package api
 
 import (
 	"fmt"
-	"github.com/metal-stack/go-hal/internal/kernel"
 	"strings"
+
+	"github.com/metal-stack/go-hal/internal/kernel"
 )
 
 // PasswordConstraints holds the constraints that are ensured for generated passwords
@@ -182,7 +183,9 @@ func (v Vendor) String() string { return vendors[v] }
 // GuessVendor will try to guess from vendor string
 func GuessVendor(vendor string) Vendor {
 	for _, v := range allVendors {
-		if strings.Contains(strings.ToLower(v.String()), strings.ToLower(vendor)) {
+		givenVendor := strings.TrimSpace(strings.ToLower(vendor))
+		possibleVendor := strings.TrimSpace(strings.ToLower(v.String()))
+		if strings.Contains(givenVendor, possibleVendor) {
 			return v
 		}
 	}

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -1,6 +1,8 @@
 package api
 
-import "testing"
+import (
+	"testing"
+)
 
 func TestVendor_String(t *testing.T) {
 	tests := []struct {
@@ -17,6 +19,30 @@ func TestVendor_String(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if got := tt.v.String(); got != tt.want {
 				t.Errorf("Vendor.String() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGuessVendor(t *testing.T) {
+	tests := []struct {
+		name   string
+		vendor string
+		want   Vendor
+	}{
+		{name: "smc", vendor: "Supermicro", want: VendorSupermicro},
+		{name: "smc with space", vendor: " Supermicro ", want: VendorSupermicro},
+		{name: "lenovo", vendor: "Lenovo", want: VendorLenovo},
+		{name: "lenovolower", vendor: "lenovo", want: VendorLenovo},
+		{name: "empty", vendor: "", want: VendorUnknown},
+		{name: "unknown", vendor: "unknown", want: VendorUnknown},
+		{name: "vagrant", vendor: "vagrant", want: VendorVagrant},
+		{name: "dell", vendor: "Dell", want: VendorDell},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := GuessVendor(tt.vendor); got != tt.want {
+				t.Errorf("GuessVendor() = %v, want %v", got, tt.want)
 			}
 		})
 	}


### PR DESCRIPTION
The actual implementation will always return the first vendor from vendorlist if vendorstring is "".

Fix this.

BUT please dont merge because this actually prevents bmc-catcher to detect the vendor !