### PR TITLE
Do not disable user before password change

### DIFF
--- a/internal/ipmi/ipmitool.go
+++ b/internal/ipmi/ipmitool.go
@@ -391,11 +391,6 @@ func (i *Ipmitool) createUser(req bmcRequest) (string, error) {
 }
 
 func (i *Ipmitool) changePassword(req bmcRequest) (string, error) {
-	err := i.setUserEnabled(req, false)
-	if err != nil {
-		return "", err
-	}
-
 	pw, err := req.setPasswordFunc()
 	if err != nil {
 		return "", fmt.Errorf("failed to set password %s for user %s with id %s %w", pw, req.username, req.uid, err)


### PR DESCRIPTION
## Description

This PR is related / replaces #71.
Enabling an already enabled user does not result in an error. Thus, it should be not necessary to disable a user upfront.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
