### PR TITLE
Check if user password change is necessary via ipmitool

### DIFF
--- a/internal/vendors/lenovo/lenovo.go
+++ b/internal/vendors/lenovo/lenovo.go
@@ -140,6 +140,10 @@ func (c *bmcConnection) CreateUser(user api.BMCUser, privilege api.IpmiPrivilege
 	return err
 }
 
+func (c *bmcConnection) NeedsPasswordChange(user api.BMCUser, password string) (bool, error) {
+	return c.IpmiTool.NeedsPasswordChange(user, password)
+}
+
 func (c *bmcConnection) ChangePassword(user api.BMCUser, newPassword string) error {
 	return c.IpmiTool.ChangePassword(user, newPassword, ipmi.LowLevel)
 }

--- a/internal/vendors/lenovo/lenovo.go
+++ b/internal/vendors/lenovo/lenovo.go
@@ -141,7 +141,7 @@ func (c *bmcConnection) CreateUser(user api.BMCUser, privilege api.IpmiPrivilege
 }
 
 func (c *bmcConnection) NeedsPasswordChange(user api.BMCUser, password string) (bool, error) {
-	return c.IpmiTool.NeedsPasswordChange(user, password)
+	return true, nil
 }
 
 func (c *bmcConnection) ChangePassword(user api.BMCUser, newPassword string) error {

--- a/internal/vendors/supermicro/supermicro.go
+++ b/internal/vendors/supermicro/supermicro.go
@@ -161,6 +161,10 @@ func (c *bmcConnection) CreateUser(user api.BMCUser, privilege api.IpmiPrivilege
 	return err
 }
 
+func (c *bmcConnection) NeedsPasswordChange(user api.BMCUser, password string) (bool, error) {
+	return c.IpmiTool.NeedsPasswordChange(user, password)
+}
+
 func (c *bmcConnection) ChangePassword(user api.BMCUser, newPassword string) error {
 	return c.IpmiTool.ChangePassword(user, newPassword, ipmi.HighLevel)
 }

--- a/internal/vendors/supermicro/supermicro.go
+++ b/internal/vendors/supermicro/supermicro.go
@@ -162,7 +162,7 @@ func (c *bmcConnection) CreateUser(user api.BMCUser, privilege api.IpmiPrivilege
 }
 
 func (c *bmcConnection) NeedsPasswordChange(user api.BMCUser, password string) (bool, error) {
-	return c.IpmiTool.NeedsPasswordChange(user, password)
+	return true, nil
 }
 
 func (c *bmcConnection) ChangePassword(user api.BMCUser, newPassword string) error {

--- a/internal/vendors/vagrant/vagrant.go
+++ b/internal/vendors/vagrant/vagrant.go
@@ -125,6 +125,10 @@ func (c *bmcConnection) CreateUser(user api.BMCUser, privilege api.IpmiPrivilege
 	return nil
 }
 
+func (c *bmcConnection) NeedsPasswordChange(user api.BMCUser, password string) (bool, error) {
+	return true, nil
+}
+
 func (c *bmcConnection) ChangePassword(user api.BMCUser, newPassword string) error {
 	return nil
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -95,6 +95,8 @@ type BMCConnection interface {
 	BMC() (*BMC, error)
 	// PresentSuperUser returns the details of the already present bmc superuser
 	PresentSuperUser() BMCUser
+	// NeedsPasswordChange checks if a password change is required
+	NeedsPasswordChange(user BMCUser, password string) (bool, error)
 	// SuperUser returns the details of the preset metal bmc superuser
 	SuperUser() BMCUser
 	// User returns the details of the preset metal bmc user


### PR DESCRIPTION
## Description

Adds a method that checks, if a user password needs to be changed.

<!--
If possible, please reference other issues or pull requests.

Closes #<the-issue-number-to-close>.

References:

- ...

If not already described in a referenced issue, please describe your PR and the motivation behind it. Just try to make life easy for the reviewers.

Please be aware that the pull request's title will become part of the release notes, so try to make it understandable.
-->

<!--
You maybe want to attach the triage label if you want it to be discussed in the next planning meeting. It might be useful to attend the meeting if you want to emphasize it.

If you would like to add something to the release notes for the next metal-stack release (metal-stack/releases), you can do so by adding SPECIAL SECTIONS (code blocks) in this PR. Please only add a section when this is relevant for the entire project.

You can use the following snippets as an example:

## Release Notes

### Breaking Change

```BREAKING_CHANGE
Description of the breaking change and what an operator needs to do about it.
This section is **not** intended for documentation of internal breaking changes.
Release notes are meant to be read by users and operators of metal-stack, not metal-stack developers.
```

### Required Actions

```ACTIONS_REQUIRED
Description of the required action for operators.
```

### Noteworthy

```NOTEWORTHY
Description of noteworthy release information for the metal-stack project that users or operators should know.
```
-->
